### PR TITLE
Remove CI flag from ReactScripts evaluator

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,8 +8,9 @@ git clone --branch $REPOSITORY_BRANCH https://github.com/$REPOSITORY_NAME.git /p
 rm -rf /project-tests/.git
 cp -r /project-tests/* .
 npm install
-npm install -g react-scripts
-CI=false react-scripts test --watchAll=false --json --outputFile=evaluation.json
+npm test -- --watchAll=false --json --outputFile=evaluation.json
+# npm install -g react-scripts
+# CI=false react-scripts test --watchAll=false --json --outputFile=evaluation.json
 node /evaluator.js evaluation.json .trybe/requirements.json result.json
 
 if [ $? != 0 ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,7 +9,7 @@ rm -rf /project-tests/.git
 cp -r /project-tests/* .
 npm install
 npm install -g react-scripts
-CI=true react-scripts test --json --outputFile=evaluation.json
+react-scripts test --watchAll=false --json --outputFile=evaluation.json
 node /evaluator.js evaluation.json .trybe/requirements.json result.json
 
 if [ $? != 0 ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,8 +9,6 @@ rm -rf /project-tests/.git
 cp -r /project-tests/* .
 npm install
 node_modules/.bin/react-scripts test --watchAll=false --json --outputFile=evaluation.json
-# npm install -g react-scripts
-# CI=false react-scripts test --watchAll=false --json --outputFile=evaluation.json
 node /evaluator.js evaluation.json .trybe/requirements.json result.json
 
 if [ $? != 0 ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,7 +9,7 @@ rm -rf /project-tests/.git
 cp -r /project-tests/* .
 npm install
 npm install -g react-scripts
-react-scripts test --watchAll=false --json --outputFile=evaluation.json
+CI=false react-scripts test --watchAll=false --json --outputFile=evaluation.json
 node /evaluator.js evaluation.json .trybe/requirements.json result.json
 
 if [ $? != 0 ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,7 +8,7 @@ git clone --branch $REPOSITORY_BRANCH https://github.com/$REPOSITORY_NAME.git /p
 rm -rf /project-tests/.git
 cp -r /project-tests/* .
 npm install
-npm test -- --watchAll=false --json --outputFile=evaluation.json
+node_modules/.bin/react-scripts test --watchAll=false --json --outputFile=evaluation.json
 # npm install -g react-scripts
 # CI=false react-scripts test --watchAll=false --json --outputFile=evaluation.json
 node /evaluator.js evaluation.json .trybe/requirements.json result.json


### PR DESCRIPTION
Utilizamos a versão mais recente do `react-scripts` juntamente com a tag `CI=true` para que a execução dos testes não precisasse de interação humana.

Por causa da thread https://betrybe.slack.com/archives/C0160E5M3A6/p1603739949141000 foi descoberto dois problemas:

1. Como a lib `react-scripts` era baixado globalmente pelo avaliador `npm install -g react-scripts`, a versão executada no avaliador poderia ser diferente da versão utilizada no projeto.
1. Utiliza a tag `CI` para escapar a interação humana, mas essa _tag_ faz mais do que isso e por esse motivo os resultados eram diferentes.

Para resolver ambos os problemas, agora o avaliador utiliza a versão baixada no projeto e executa o mesmo comando executado pelo script `npm test`, só que adiciona algumas configurações para viabilizar a avaliação.


Validação

Para validar basta criar um PR em um projeto que utiliza o avaliador `react-scripts` com a seguinte alteração:
`.github/workflows/main.yml
```
- name: Evaluator step
  id: evaluator
  uses: betrybe/react-scripts-evaluator-action@fix/remove-ci-true-flag
```

A avaliação deve ocorrer com sucesso.