### PR TITLE
imp: recebe username como input

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ React Scripts unit tests JSON results in base64 format.
 
 ```yml
 - uses: betrybe/react-scripts-evaluator-action@v5
+  with:
+    pr_author_username: ${{ github.event.inputs.pr_author_username }}
 ```
 
 ## How to get result output
@@ -28,6 +30,8 @@ React Scripts unit tests JSON results in base64 format.
 - name: React Scripts evaluator
   id: evaluator
   uses: betrybe/react-scripts-evaluator-action@v5
+  with:
+    pr_author_username: ${{ github.event.inputs.pr_author_username }}
 - name: Next step
   uses: another-github-action
   with:

--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@ This action evaluate Tryber projects with [React Scripts](https://www.npmjs.com/
 
 ## Inputs
 
+- `pr_author_username`
+
+  **Required**
+
+  Pull Request author username.
+
 ## Outputs
 
 ### `result`

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,9 @@
 name: 'React Scripts evaluator'
 description: 'React Scripts evaluator action for Tryber projects'
+inputs:
+  pr_author_username:
+    description: 'Pull Request author username'
+    required: true
 outputs:
   result:
     description: 'React Scripts unit tests JSON results in base64 format.'

--- a/evaluator.js
+++ b/evaluator.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const CORRECT_ANSWER_GRADE = 3;
 const WRONG_ANSWER_GRADE = 1;
 
-const githubUsername = process.env.GITHUB_ACTOR || 'no_actor';
+const githubUsername = process.env.INPUT_PR_AUTHOR_USERNAME || 'no_actor';
 const githubRepositoryName = process.env.GITHUB_REPOSITORY || 'no_repository';
 
 const jestOuputFile = fs.readFileSync(process.argv[2]);


### PR DESCRIPTION
Devido as alterações na [LEARN-869](https://trybe.atlassian.net/browse/LEARN-869?atlOrigin=eyJpIjoiNjk5MjBkZDIzNTM2NDY5NmExMGJjYmRjN2NlZDAzYjAiLCJwIjoiaiJ9) e como o _workflow_ é disparado via **Github App Selfhosted**, a envvar `GITHUB_ACTOR` não poderá ser usada para pegar o **username** da pessoa estudante. Além disso, o **número** da Pull Request não vem no contexto do evento da _action_. Foi modificado para estes dados serem enviados pelo Github App via _input_. Assim sendo, será necessário modificar os avaliadores para o novo formato.